### PR TITLE
Improve Dark-Mode UI on Windows

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1,4 +1,4 @@
-﻿/***********************************************************************
+/***********************************************************************
  *
  * Copyright (C) 2014-2022 wereturtle
  * Copyright (C) 2009, 2010, 2011, 2012, 2013, 2014 Graeme Gott <graeme@gottcode.org>
@@ -355,6 +355,10 @@ MainWindow::MainWindow(const QString &filePath, QWidget *parent)
 
     // Need this call for GTK / Gnome 42 segmentation fault workaround.
     qApp->processEvents();
+
+    #ifdef Q_OS_WIN
+    applyWindowsDarkUI();
+    #endif
 
     show();
 
@@ -1539,6 +1543,39 @@ void MainWindow::adjustEditor()
     // Scroll to cursor position.
     this->editor->centerCursor();
 }
+
+#ifdef Q_OS_WIN
+void MainWindow::applyWindowsDarkUI(){
+    QSettings settings("HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize",QSettings::NativeFormat);
+    if(settings.value("AppsUseLightTheme")==0) {
+        qApp->setStyle(QStyleFactory::create("Fusion"));
+        QPalette darkPalette;
+        QColor darkColor = QColor(45,45,45);
+        QColor disabledColor = QColor(127,127,127);
+        darkPalette.setColor(QPalette::Window, darkColor);
+        darkPalette.setColor(QPalette::WindowText, Qt::white);
+        darkPalette.setColor(QPalette::Base, QColor(18,18,18));
+        darkPalette.setColor(QPalette::AlternateBase, darkColor);
+        darkPalette.setColor(QPalette::ToolTipBase, Qt::white);
+        darkPalette.setColor(QPalette::ToolTipText, Qt::white);
+        darkPalette.setColor(QPalette::Text, Qt::white);
+        darkPalette.setColor(QPalette::Disabled, QPalette::Text, disabledColor);
+        darkPalette.setColor(QPalette::Button, darkColor);
+        darkPalette.setColor(QPalette::ButtonText, Qt::white);
+        darkPalette.setColor(QPalette::Disabled, QPalette::ButtonText, disabledColor);
+        darkPalette.setColor(QPalette::BrightText, Qt::red);
+        darkPalette.setColor(QPalette::Link, QColor(110, 110, 110));
+
+        darkPalette.setColor(QPalette::Highlight, QColor(110, 110, 110));
+        darkPalette.setColor(QPalette::HighlightedText, Qt::black);
+        darkPalette.setColor(QPalette::Disabled, QPalette::HighlightedText, disabledColor);
+
+        qApp->setPalette(darkPalette);
+
+        qApp->setStyleSheet("QToolTip { color: #ffffff; background-color: #2a82da; border: 1px solid white; }");
+    }
+}
+#endif
 
 void MainWindow::applyTheme()
 {

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -164,6 +164,10 @@ private:
     void buildMenuBar();
     void buildStatusBar();
     void buildSidebar();
+    
+#ifdef Q_OS_WIN
+    void applyWindowsDarkUI();
+#endif
 
     void adjustEditor();
 };


### PR DESCRIPTION
This change improves the Dark-Mode UI under Windows, using Qt Stylesheets.

It makes the UI match the native Dark Windows UI on Windows 10/11 much better than the "vanilla" look.

### Before:

![image](https://user-images.githubusercontent.com/19617165/179771607-f508a594-5cf6-485d-af2c-562013faf11b.png)

### After:

![image](https://user-images.githubusercontent.com/19617165/179946942-20581d06-7f3b-449f-892a-ed567eebfd15.png)

The "Dark Mode" is only enabled IF the Windows UI is *also* set to Dark. Otherwise it does nothing.

---

Edit: When I first submitted this PR, there was an "orange" highlight color around buttons and menu-selections. This is now gray to better match generic dark UIs.

Also note, in the "After" screenshot, the icon is changed to blue, but this is **not** part of this PR. I simply changed it locally on my build to match my system UI.