### PR TITLE
src: Add support for pasting images from clipboard

### DIFF
--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -94,6 +94,7 @@ private slots:
     void changeFont();
     void onFontSizeChanged(int size);
     void onSetLocale();
+    void pasteImage();
     void copyHtml();
     void showPreviewOptions();
     void onAboutToHideMenuBarMenu();


### PR DESCRIPTION
* This is a very useful feature that ghostwriter was lacking, and already referenced in https://github.com/KDE/ghostwriter/issues/31
* To achieve this, allow the user to choose the filename and directory manually in the file explorer, but providing a default name and path to store images to

Signed-off-by: Davide Garberi <dade.garberi@gmail.com>