### PR TITLE
Add Preview Only view mode (F8)

### DIFF
--- a/src/appactions.cpp
+++ b/src/appactions.cpp
@@ -216,6 +216,7 @@ AppActions::AppActions(KActionCollection *collection, SvgIconTheme *iconTheme, Q
     d->addCheckAction(DistractionFreeMode, "view_distraction_free_mode", tr("Distraction-Free Mode"), "distraction-free-mode", tr("SHIFT+F11"));
 
     d->addCheckAction(Preview, "view_preview", tr("Live Preview"), "live-preview", tr("CTRL+P"));
+    d->addCheckAction(PreviewOnly, "view_preview_only", tr("Preview Only"), "live-preview", tr("F8"));
 
     action = d->addCheckAction(HemingwayMode, "view_hemingway_mode", tr("Hemingway Mode"), "hemingway-mode", tr("SHIFT+Backspace"));
     action->setToolTip(tr("Toggles Hemingway mode."));

--- a/src/appactions.h
+++ b/src/appactions.h
@@ -96,6 +96,7 @@ public:
         FullScreen,
         DistractionFreeMode,
         Preview,
+        PreviewOnly,
         HemingwayMode,
         DarkMode,
         ShowMenubar,

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: 2014-2025 Megan Conkle <megan.conkle@kdemail.net>
  * SPDX-FileCopyrightText: 2009-2014 Graeme Gott <graeme@gottcode.org>
  *
@@ -314,11 +314,35 @@ void MainWindow::openPreferencesDialog()
 
 void MainWindow::toggleHtmlPreview(bool checked)
 {
+    if (appAction(AppActions::PreviewOnly)->isChecked()) {
+        return;
+    }
     htmlPreview->setVisible(checked);
     htmlPreview->updatePreview();
     appSettings->setHtmlPreviewVisible(checked);
     this->update();
     adjustEditor();
+}
+
+void MainWindow::togglePreviewOnly(bool checked)
+{
+    if (checked) {
+        appAction(AppActions::Preview)->setChecked(true);
+        sidebar->setVisible(false);
+        editor->setVisible(false);
+        htmlPreview->setVisible(true);
+        htmlPreview->setMaximumWidth(16777215);
+        htmlPreview->updatePreview();
+        htmlPreview->setFocus();
+    } else {
+        sidebar->setVisible(appSettings->sidebarVisible());
+        editor->setVisible(true);
+        htmlPreview->setVisible(appSettings->htmlPreviewVisible());
+        appAction(AppActions::Preview)->setChecked(appSettings->htmlPreviewVisible());
+        adjustEditor();
+        editor->setFocus();
+    }
+    this->update();
 }
 
 void MainWindow::toggleHemingwayMode(bool checked)
@@ -802,6 +826,8 @@ void MainWindow::setupActions()
     m_actions->connect(AppActions::DistractionFreeMode, this, &MainWindow::toggleFocusMode);
     appAction(AppActions::Preview)->setChecked(appSettings->htmlPreviewVisible());
     m_actions->connect(AppActions::Preview, this, &MainWindow::toggleHtmlPreview);
+    appAction(AppActions::PreviewOnly)->setChecked(false);
+    m_actions->connect(AppActions::PreviewOnly, this, &MainWindow::togglePreviewOnly);
     m_actions->connect(AppActions::HemingwayMode, this, &MainWindow::toggleHemingwayMode);
     appAction(AppActions::DarkMode)->setChecked(appSettings->darkModeEnabled());
     m_actions->connect(AppActions::DarkMode, this, [this](bool enabled) {
@@ -1077,6 +1103,7 @@ void MainWindow::setupMenuBar()
     menu->addAction(appAction(AppActions::FullScreen));
     menu->addAction(appAction(AppActions::DistractionFreeMode));
     menu->addAction(appAction(AppActions::Preview));
+    menu->addAction(appAction(AppActions::PreviewOnly));
     menu->addAction(appAction(AppActions::HemingwayMode));
     menu->addAction(appAction(AppActions::DarkMode));
     menu->addSeparator();
@@ -1365,6 +1392,11 @@ void MainWindow::adjustEditor()
 {
     // Make sure editor size is updated.
     qApp->processEvents();
+
+    if (appAction(AppActions::PreviewOnly)->isChecked()) {
+        htmlPreview->setMaximumWidth(16777215);
+        return;
+    }
 
     int width = this->width();
     int sidebarWidth = 0;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: 2014-2024 Megan Conkle <megan.conkle@kdemail.net>
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
@@ -66,6 +66,7 @@ private slots:
     void changeTheme();
     void openPreferencesDialog();
     void toggleHtmlPreview(bool checked);
+    void togglePreviewOnly(bool checked);
     void toggleHemingwayMode(bool checked);
     void toggleFocusMode(bool checked);
     void toggleFullScreen(bool checked);


### PR DESCRIPTION
## Summary
Adds a "Preview Only" toggle so users can view the rendered Markdown without the editor or sidebar.

## Changes
- **View → Preview Only** (shortcut **F8**): when checked, only the HTML preview is shown; editor and sidebar hidden, preview full width. When unchecked, previous layout is restored.
- Live Preview cannot be turned off while Preview Only is active.

## Testing
Open a .md file → View → Preview Only (or F8) → only preview visible. Toggle again → editor and sidebar back.