### PR TITLE
Enhance type safety by replacing `any` with `unknown` in mhchemParser

### DIFF
--- a/3rdparty/MathJax/src/ts/input/tex/mhchem/mhchem_parser.d.ts
+++ b/3rdparty/MathJax/src/ts/input/tex/mhchem/mhchem_parser.d.ts
@@ -1,5 +1,5 @@
 export declare namespace mhchemParser {
-  export function go(input: string, stateMachine: string): any[];
+  export function go(input: string, stateMachine: string): unknown[];
 }
 
 export declare namespace texify {


### PR DESCRIPTION
## 问题背景
在 `mhchem_parser.d.ts` 文件中，函数 `go` 的返回类型被声明为 `any[]`。使用 `any` 类型会绕过 TypeScript 的类型检查，这可能导致运行时类型错误，降低代码的可靠性和可维护性。

## 修改内容
将函数 `go` 的返回类型从 `any[]` 改为 `unknown[]`。`unknown` 类型更严格，要求在使用返回值之前进行类型检查或断言，从而增强类型安全性，而不改变函数的功能或 API。

## 验证方式
- 编译 TypeScript 项目以确保没有引入新的类型错误。
- 运行现有测试用例（如果存在）以验证功能保持不变。
- 由于这是一个纯类型注解的改动，它不影响运行时行为，仅提升编译时安全检查。